### PR TITLE
Add Vagrant config for python3 dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Local environment
+.DS_Store
+Thumbs.db
+
+# Vagrant
+.vagrant
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure("2") do |config|
     pip3 install -U pip
     apt-get -y autoremove
     # Install app dependencies
-    # cd /vagrant
-    # sudo pip install -r requirements.txt
+    cd /vagrant
+    sudo pip install -r requirements.txt
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,42 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/xenial64"
+
+  # Set up network IP and Port forwarding
+  config.vm.network "forwarded_port", guest: 5000, host: 5000, host_ip: "127.0.0.1"
+  config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  config.vm.provider "virtualbox" do |vb|
+    # Customize the amount of memory and cpus on the VM:
+    vb.memory = "512"
+    vb.cpus = 1
+  end
+
+  # Copy your .gitconfig file so that your git credentials are correct
+  if File.exists?(File.expand_path("~/.gitconfig"))
+    config.vm.provision "file", source: "~/.gitconfig", destination: "~/.gitconfig"
+  end
+
+  # Copy your ssh keys for github so that your git credentials work
+  if File.exists?(File.expand_path("~/.ssh/id_rsa"))
+    config.vm.provision "file", source: "~/.ssh/id_rsa", destination: "~/.ssh/id_rsa"
+  end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available.
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get install -y git python3 python3-pip
+    pip3 install -U pip
+    apt-get -y autoremove
+    # Install app dependencies
+    # cd /vagrant
+    # sudo pip install -r requirements.txt
+  SHELL
+end


### PR DESCRIPTION
This sets up the environment for local development. It configures a Xenial (16.04 LTS) Ubuntu box with Git (including your credentials), Python 3, and Pip3.

Only difference with python 3 is you'll need to use the command `python3` on the command line instead of the default `python`.

It also includes the commands for when we have a Flask app and python requirements file. Lines 39 and 40 will just need to be uncommented.