### PR TITLE
Add product to a shopcart

### DIFF
--- a/models/dataerror.py
+++ b/models/dataerror.py
@@ -1,0 +1,3 @@
+class DataValidationError(Exception):
+    """ Used for an data validation errors """
+    pass

--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -24,8 +24,9 @@ class Shopcart(object):
         """ Saves a Shopcart in the database """
         Shopcart.__data.append(self)
 
-    def add_product(self, pq_tup):
+    def add_product(self, pid, quant=1):
         """ Adds a tuple of product, quantity to the product dict """
+        pq_tup = (pid,quant)
         self.products.update( self.__validate_products(pq_tup) )
 
     @staticmethod

--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -1,34 +1,32 @@
+from .dataerror import DataValidationError
 class Shopcart(object):
-
     """
     This is model for the shop carts
     Assumptions:
         - In memory persistence
         - The fields of a shopcart include:
             - user id
-            - list of products (product id, quantity of product )
+            - Dictionary of products { product_id: quantity_of_product}
         - The total price of the shopcart will be dynamically calculated
-        - Model should only initially include `init` method and shopcart fields
-
     """
-
     __data = []
     __index = 0
-
-    __products = dict()
 
     def __init__(self, uid=0, products=None):
         """
         :param uid: user id
         :param products: dict of products <products id, quantity of product>
         """
-
         self.uid = int(uid)
-        self.products = products if products else []
+        self.products = self.__validate_products(products)
 
     def save(self):
         """ Saves a Shopcart in the database """
         Shopcart.__data.append(self)
+
+    def add_product(self, pq_tup):
+        """ Adds a tuple of product, quantity to the product dict """
+        self.products.update( self.__validate_products(pq_tup) )
 
     @staticmethod
     def all():
@@ -39,3 +37,36 @@ class Shopcart(object):
     def remove_all():
         """ Remove all Shopcarts from memory """
         Shopcart.__data = []
+
+    @staticmethod
+    def __validate_products(products):
+        """ Validates products or raises an error"""
+        try:
+            # Product is none so set an empty list
+            if products is None:
+                return {}
+            
+            #Not None
+            # Tuple of product, quantity 
+            if type(products) == tuple  and len(products)==2 and all(isinstance(pq,int) for pq in products): 
+                return {products[0]:products[1]}
+
+            # Just a Product id, set default quantity to 1
+            if type(products) == int: 
+                return {products:1}
+
+            if type(products) != dict : 
+                raise DataValidationError() 
+            
+            # Products is a dict of proper tuples
+            if ( all( isinstance(pid,int) for pid in products.keys() ) and
+                 all( (isinstance(q,int) and (q > 0)) for q in products.values() ) ):
+                return products
+
+            #Products not valid
+            raise DataValidationError() 
+
+        except DataValidationError as e:
+            print(type(e)) 
+            print('ERROR: Products were not added to shopcart.')
+            return {}

--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -19,7 +19,7 @@ class Shopcart(object):
         """
         self.uid = int(uid)
         self.products = self.__validate_products(products)
-
+        
     def save(self):
         """ Saves a Shopcart in the database """
         Shopcart.__data.append(self)
@@ -57,7 +57,8 @@ class Shopcart(object):
                 return {products:1}
 
             if type(products) != dict : 
-                raise DataValidationError() 
+                raise DataValidationError("Invalid format for products")
+
             
             # Products is a dict of proper tuples
             if ( all( isinstance(pid,int) for pid in products.keys() ) and
@@ -65,9 +66,8 @@ class Shopcart(object):
                 return products
 
             #Products not valid
-            raise DataValidationError() 
+            raise DataValidationError("Invalid format for products")
 
         except DataValidationError as e:
-            print(type(e)) 
-            print('ERROR: Products were not added to shopcart.')
+            print('ERROR: Data Validation error' +e.args[0])
             return {}

--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -18,8 +18,11 @@ class Shopcart(object):
         :param products: dict of products <products id, quantity of product>
         """
         self.uid = int(uid)
-        self.products = self.__validate_products(products)
-        
+        try:
+            self.products = self.__validate_products(products)
+        except DataValidationError as e:
+            print('ERROR: Data Validation error' +e.args[0])           
+
     def save(self):
         """ Saves a Shopcart in the database """
         Shopcart.__data.append(self)
@@ -27,7 +30,11 @@ class Shopcart(object):
     def add_product(self, pid, quant=1):
         """ Adds a tuple of product, quantity to the product dict """
         pq_tup = (pid,quant)
-        self.products.update( self.__validate_products(pq_tup) )
+        try:
+            self.products.update( self.__validate_products(pq_tup) )
+        except DataValidationError as e:
+            print('ERROR: Data Validation error' +e.args[0])
+
 
     @staticmethod
     def all():
@@ -42,32 +49,26 @@ class Shopcart(object):
     @staticmethod
     def __validate_products(products):
         """ Validates products or raises an error"""
-        try:
-            # Product is none so set an empty list
-            if products is None:
-                return {}
-            
-            #Not None
-            # Tuple of product, quantity 
-            if type(products) == tuple  and len(products)==2 and all(isinstance(pq,int) for pq in products): 
-                return {products[0]:products[1]}
+        # Product is none so set an empty list
+        if products is None:
+            return {}
 
-            # Just a Product id, set default quantity to 1
-            if type(products) == int: 
-                return {products:1}
+        #Not None
+        # Tuple of product, quantity 
+        if type(products) == tuple  and len(products)==2 and all(isinstance(pq,int) for pq in products): 
+            return {products[0]:products[1]}
 
-            if type(products) != dict : 
-                raise DataValidationError("Invalid format for products")
+        # Just a Product id, set default quantity to 1
+        if type(products) == int: 
+            return {products:1}
 
-            
-            # Products is a dict of proper tuples
-            if ( all( isinstance(pid,int) for pid in products.keys() ) and
-                 all( (isinstance(q,int) and (q > 0)) for q in products.values() ) ):
-                return products
-
-            #Products not valid
+        if type(products) != dict : 
             raise DataValidationError("Invalid format for products")
 
-        except DataValidationError as e:
-            print('ERROR: Data Validation error' +e.args[0])
-            return {}
+        # Products is a dict of proper tuples
+        if ( all( isinstance(pid,int) for pid in products.keys() ) and
+             all( (isinstance(q,int) and (q > 0)) for q in products.values() ) ):
+            return products
+
+        #Products not valid
+        raise DataValidationError("Invalid format for products")

--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -18,10 +18,7 @@ class Shopcart(object):
         :param products: dict of products <products id, quantity of product>
         """
         self.uid = int(uid)
-        try:
-            self.products = self.__validate_products(products)
-        except DataValidationError as e:
-            print('ERROR: Data Validation error' +e.args[0])           
+        self.products = self.__validate_products(products)
 
     def save(self):
         """ Saves a Shopcart in the database """
@@ -30,10 +27,7 @@ class Shopcart(object):
     def add_product(self, pid, quant=1):
         """ Adds a tuple of product, quantity to the product dict """
         pq_tup = (pid,quant)
-        try:
-            self.products.update( self.__validate_products(pq_tup) )
-        except DataValidationError as e:
-            print('ERROR: Data Validation error' +e.args[0])
+        self.products.update( self.__validate_products(pq_tup) )
 
 
     @staticmethod
@@ -63,7 +57,7 @@ class Shopcart(object):
             return {products:1}
 
         if type(products) != dict : 
-            raise DataValidationError("Invalid format for products")
+            raise DataValidationError("ERROR: Data Validation error\nInvalid format for products")
 
         # Products is a dict of proper tuples
         if ( all( isinstance(pid,int) for pid in products.keys() ) and
@@ -71,4 +65,4 @@ class Shopcart(object):
             return products
 
         #Products not valid
-        raise DataValidationError("Invalid format for products")
+        raise DataValidationError("ERROR: Data Validation error\nInvalid format for products")

--- a/tests/test_shopcart.py
+++ b/tests/test_shopcart.py
@@ -33,26 +33,39 @@ class TestShopcart(unittest.TestCase):
     def test_string_is_invalid_product(self):
         """Test that strings are not accepted as products"""
         # Passing a string
-        shopcart = Shopcart(1,'product1')
-        self.assertRaises(DataValidationError)
+        try:
+            shopcart = Shopcart(1,'product1')
+            self.assertRaises(DataValidationError)
+        except DataValidationError as e:
+            print(e.args[0])
+        
 
     def test_float_is_invalid_product(self):
         """Test that floats are not accepted as products"""
         # Passing a double
-        shopcart = Shopcart(1,2.0)
-        self.assertRaises(DataValidationError)
-
+        try:
+            shopcart = Shopcart(1,2.0)
+            self.assertRaises(DataValidationError)
+        except DataValidationError as e:
+            print(e.args[0])
+            
     def test_list_is_invalid_product(self):
         """Test for not allowing lists in products"""
         # No list
-        shopcart = Shopcart(1,[])
-        self.assertRaises(DataValidationError)
-
+        try:
+            shopcart = Shopcart(1,[])
+            self.assertRaises(DataValidationError)
+        except DataValidationError as e:
+            print(e.args[0])
+            
     def test_set_is_invalid_product(self):
         """Test for not allowing sets in products"""
         # Passing a set
-        shopcart = Shopcart(1,{1})
-        self.assertRaises(DataValidationError)
+        try:
+            shopcart = Shopcart(1,{1})
+            self.assertRaises(DataValidationError)
+        except DataValidationError as e:
+            print(e.args[0])
 
     def test_that_products_are_always_a_dict(self):
         """Test that the shopcart model has products as a dict"""
@@ -137,13 +150,19 @@ class TestShopcart(unittest.TestCase):
         self.assertEqual( len(s.products) , 0 )
         
         # Adding product 21.5
-        s.add_product( 21.5 )
-        self.assertRaises( DataValidationError )
+        try:
+            s.add_product( 21.5 )
+            self.assertRaises( DataValidationError )
+        except DataValidationError as e:
+            print(e.args[0])
 
         # Adding a second error
-        s.add_product( 34, 0.5 )
-        self.assertEqual( len(s.products) ,0 )
-        self.assertRaises( DataValidationError )
+        try:
+            s.add_product( 34, 0.5 )
+            self.assertEqual( len(s.products) ,0 )
+            self.assertRaises( DataValidationError )
+        except DataValidationError as e:
+            print(e.args[0])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_shopcart.py
+++ b/tests/test_shopcart.py
@@ -34,28 +34,24 @@ class TestShopcart(unittest.TestCase):
         """Test that strings are not accepted as products"""
         # Passing a string
         shopcart = Shopcart(1,'product1')
-        self.assertTrue( len(shopcart.products) == 0)
         self.assertRaises(DataValidationError)
 
     def test_float_is_invalid_product(self):
         """Test that floats are not accepted as products"""
         # Passing a double
         shopcart = Shopcart(1,2.0)
-        self.assertTrue( len(shopcart.products) == 0)
         self.assertRaises(DataValidationError)
 
     def test_list_is_invalid_product(self):
         """Test for not allowing lists in products"""
         # No list
         shopcart = Shopcart(1,[])
-        self.assertTrue( len(shopcart.products) == 0)
         self.assertRaises(DataValidationError)
 
     def test_set_is_invalid_product(self):
         """Test for not allowing sets in products"""
         # Passing a set
         shopcart = Shopcart(1,{1})
-        self.assertTrue( len(shopcart.products) == 0)
         self.assertRaises(DataValidationError)
 
     def test_that_products_are_always_a_dict(self):

--- a/tests/test_shopcart.py
+++ b/tests/test_shopcart.py
@@ -118,14 +118,14 @@ class TestShopcart(unittest.TestCase):
         self.assertEqual( len(s.products) , 0 )
         
         # Adding product 21 with quant 34
-        s.add_product( (21,34) )
+        s.add_product( 21,34 )
         #There's only one product
         self.assertEqual( len(s.products) ,1 )
         # It's the correct one with correct quant
         self.assertEqual( s.products[21] , 34 )
 
-        # Adding a dictionary 
-        s.add_product( {34:55} )
+        # Adding a second 
+        s.add_product( 34, 55 )
         #There's two  products
         self.assertEqual( len(s.products) ,2 )
         # It's the correct one with correct quant

--- a/tests/test_shopcart.py
+++ b/tests/test_shopcart.py
@@ -33,43 +33,23 @@ class TestShopcart(unittest.TestCase):
     def test_string_is_invalid_product(self):
         """Test that strings are not accepted as products"""
         # Passing a string
-        try:
+        with self.assertRaises(DataValidationError):
             shopcart = Shopcart(1,'product1')
-            self.assertRaises(DataValidationError)
-        except DataValidationError as e:
-            print(e.args[0])
-        
 
     def test_float_is_invalid_product(self):
         """Test that floats are not accepted as products"""
         # Passing a double
-        try:
+        with self.assertRaises(DataValidationError):
             shopcart = Shopcart(1,2.0)
-            self.assertRaises(DataValidationError)
-        except DataValidationError as e:
-            print(e.args[0])
-            
-    def test_list_is_invalid_product(self):
-        """Test for not allowing lists in products"""
-        # No list
-        try:
-            shopcart = Shopcart(1,[])
-            self.assertRaises(DataValidationError)
-        except DataValidationError as e:
-            print(e.args[0])
             
     def test_set_is_invalid_product(self):
         """Test for not allowing sets in products"""
         # Passing a set
-        try:
+        with self.assertRaises(DataValidationError):
             shopcart = Shopcart(1,{1})
-            self.assertRaises(DataValidationError)
-        except DataValidationError as e:
-            print(e.args[0])
 
     def test_that_products_are_always_a_dict(self):
         """Test that the shopcart model has products as a dict"""
-        
         # Initializing just an id without product
         shopcart = Shopcart(1)
         self.assertTrue( type(shopcart.products) == dict )
@@ -150,26 +130,19 @@ class TestShopcart(unittest.TestCase):
         self.assertEqual( len(s.products) , 0 )
         
         # Adding product 21.5
-        try:
+        with self.assertRaises(DataValidationError):
             s.add_product( 21.5 )
-            self.assertRaises( DataValidationError )
-        except DataValidationError as e:
-            print(e.args[0])
 
         # Adding a second error
-        try:
+        with self.assertRaises(DataValidationError):
             s.add_product( 34, 0.5 )
-            self.assertEqual( len(s.products) ,0 )
-            self.assertRaises( DataValidationError )
-        except DataValidationError as e:
-            print(e.args[0])
 
     def test_get_all_shopcarts(self):
         """ Test All Shopcarts Can Be Retrieved """
         # Add 3 shopcarts to memory and check that we can retrieve them all
-        cart1 = Shopcart(1, [])
-        cart2 = Shopcart(2, [])
-        cart3 = Shopcart(3, [])
+        cart1 = Shopcart(1)
+        cart2 = Shopcart(2)
+        cart3 = Shopcart(3)
         cart1.save()
         cart2.save()
         cart3.save()

--- a/tests/test_shopcart.py
+++ b/tests/test_shopcart.py
@@ -131,5 +131,23 @@ class TestShopcart(unittest.TestCase):
         # It's the correct one with correct quant
         self.assertEqual( s.products[34] , 55 )
 
+    def test_adding_an_invalid_product(self):
+        """ Test to add invalid product"""
+        shopcart = Shopcart(21)
+        shopcart.save()
+        shopcarts = shopcart.all()
+        s=shopcarts[0]
+        self.assertEqual( s.uid ,21 )
+        self.assertEqual( len(s.products) , 0 )
+        
+        # Adding product 21.5
+        s.add_product( 21.5 )
+        self.assertRaises( DataValidationError )
+
+        # Adding a second error
+        s.add_product( 34, 0.5 )
+        self.assertEqual( len(s.products) ,0 )
+        self.assertRaises( DataValidationError )
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_shopcart.py
+++ b/tests/test_shopcart.py
@@ -1,5 +1,6 @@
 import unittest
 from models.shopcart import Shopcart
+from models.dataerror import DataValidationError
 
 class TestShopcart(unittest.TestCase):
     """ Shopcart Model Tests """
@@ -8,9 +9,9 @@ class TestShopcart(unittest.TestCase):
 
     def test_it_can_be_instantiated(self):
         """ Test Instantiation """
-        cart = Shopcart(1,[])
+        cart = Shopcart(1)
         self.assertEqual(cart.uid, 1)
-        self.assertEqual(cart.products, [])
+        self.assertEqual(cart.products,{})
 
     def test_it_can_be_saved(self):
         """ Test Model is Saved to Memory """
@@ -19,7 +20,7 @@ class TestShopcart(unittest.TestCase):
         self.assertEqual(len(items), 0)
 
         # Save a shopcart and check it was added to memory
-        cart = Shopcart(1,[])
+        cart = Shopcart(1)
         cart.save()
         items = Shopcart.all()
         self.assertEqual(len(items), 1)
@@ -27,7 +28,108 @@ class TestShopcart(unittest.TestCase):
         # Check that the saved item is actually the one we saved
         fetched = items[0]
         self.assertEqual(fetched.uid,1)
-        self.assertEqual(fetched.products,[])
+        self.assertEqual(fetched.products,{})
+
+    def test_string_is_invalid_product(self):
+        """Test that strings are not accepted as products"""
+        # Passing a string
+        shopcart = Shopcart(1,'product1')
+        self.assertTrue( len(shopcart.products) == 0)
+        self.assertRaises(DataValidationError)
+
+    def test_float_is_invalid_product(self):
+        """Test that floats are not accepted as products"""
+        # Passing a double
+        shopcart = Shopcart(1,2.0)
+        self.assertTrue( len(shopcart.products) == 0)
+        self.assertRaises(DataValidationError)
+
+    def test_list_is_invalid_product(self):
+        """Test for not allowing lists in products"""
+        # No list
+        shopcart = Shopcart(1,[])
+        self.assertTrue( len(shopcart.products) == 0)
+        self.assertRaises(DataValidationError)
+
+    def test_set_is_invalid_product(self):
+        """Test for not allowing sets in products"""
+        # Passing a set
+        shopcart = Shopcart(1,{1})
+        self.assertTrue( len(shopcart.products) == 0)
+        self.assertRaises(DataValidationError)
+
+    def test_that_products_are_always_a_dict(self):
+        """Test that the shopcart model has products as a dict"""
+        
+        # Initializing just an id without product
+        shopcart = Shopcart(1)
+        self.assertTrue( type(shopcart.products) == dict )
+
+        # initializing None as products
+        shopcart = Shopcart(1,None)
+        self.assertTrue(type(shopcart.products) == dict )
+
+        # initializing empty dict
+        shopcart = Shopcart(1,{})
+        self.assertTrue(type(shopcart.products) == dict )
+
+        # Passing just a product id
+        shopcart = Shopcart(1,5)
+        self.assertTrue(type(shopcart.products) == dict )
+
+        # A dictionary of products
+        shopcart = Shopcart(1,{2:3,5:8,13:21})
+        self.assertTrue(type(shopcart.products) == dict )
+
+    def test_initializing_with_products(self):
+        """Testing initializing a cart with products """
+        # Create a new shopcart without a product
+        shopcart = Shopcart(0)
+        self.assertTrue( len(shopcart.products) == 0)
+
+        # Create a new shopcart with a product
+        shopcart = Shopcart(0,5)
+        self.assertTrue( len(shopcart.products) > 0)
+        self.assertEqual( shopcart.products , {5:1} )
+
+        # Creating a valid dictionary 
+        shopcart = Shopcart(0, {5:7,13:21,34:55 } )
+        self.assertEqual( shopcart.products , {5:7,13:21,34:55 } )
+
+        # Saving products
+        shopcart.save()
+        shopcarts = Shopcart.all()
+        self.assertTrue( len(shopcarts) > 0)
+
+        #Correct Type
+        s = shopcarts[0]
+        self.assertTrue( type(s.products) == dict)
+        
+        #Correct Length
+        self.assertEqual( len(s.products) , 3)
+
+    def test_adding_with_a_product(self):
+        """ Test to add a product to an exiting shopcart"""
+        shopcart = Shopcart(7)
+        shopcart.save()
+        shopcarts = shopcart.all()
+        s=shopcarts[0]
+        self.assertEqual( s.uid ,7 )
+        self.assertEqual( len(s.products) , 0 )
+        
+        # Adding product 21 with quant 34
+        s.add_product( (21,34) )
+        #There's only one product
+        self.assertEqual( len(s.products) ,1 )
+        # It's the correct one with correct quant
+        self.assertEqual( s.products[21] , 34 )
+
+        # Adding a dictionary 
+        s.add_product( {34:55} )
+        #There's two  products
+        self.assertEqual( len(s.products) ,2 )
+        # It's the correct one with correct quant
+        self.assertEqual( s.products[34] , 55 )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implements the add_product method in the shop cart model.
Made some modifications for constancy with the fact that products is a dictionary.
It should pass all the 7 new test cases that were created.

*Note:* A new model for validating data was created.

**To run test:**
`nosetests`


**Expected output:**
```
Product Model Tests 
- Test Instantiation

Shopcarts Server Tests 
- Test the Home Page

Shopcart Model Tests 
- Test to add a product to an exiting shopcart
- Test that floats are not accepted as products
- Testing initializing a cart with products
- Test Instantiation
- Test Model is Saved to Memory
- Test for not allowing lists in products
- Test for not allowing sets in products
- Test that strings are not accepted as products
- Test that the shopcart model has products as a dict

Name                  Stmts   Miss  Cover
-----------------------------------------
models/__init__.py        0      0   100%
models/dataerror.py       2      0   100%
models/product.py         8      0   100%
models/shopcart.py       32      1    97%
server.py                10      1    90%
-----------------------------------------
TOTAL                    52      2    96%
----------------------------------------------------------------------
Ran 11 tests in 0.370s

OK

```
