### PR TITLE
Create a shopcart from the REST API POST

### DIFF
--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -37,6 +37,23 @@ class Shopcart(object):
         """ Serializes a shopcart into a dictionary """
         return {"uid": self.uid, "products": self.products }
 
+    def deserialize(self,data):
+        """ Deserializes a shopcart from a dictionary """
+        self.uid = self.get_available_id()
+        if type( data ) != dict :
+            raise DataValidationError('Invalid shopcart: body of request contained bad or no data')
+
+        if "products" in data.keys():
+            try:
+                if type( data['products'] ) == dict:
+                    prods = { int(p):int(q) for (p,q) in data['products'].items() }
+                else:
+                    prods = int( data['products'] )
+                self.products = self.__validate_products( prods )
+            except ValueError as e:
+                raise DataValidationError('ERROR: %s has an invalid format for products'% data['products'])
+        return
+
     def get_available_id(self):
         uid=0
         while self.find(uid):

--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -60,12 +60,6 @@ class Shopcart(object):
                 raise DataValidationError('ERROR: %s has an invalid format for products'% data['products'])
         return
 
-    def get_available_id(self):
-        uid=0
-        while self.find(uid):
-            uid +=1
-        return uid
-
     @staticmethod
     def all():
         """ Query that returns all Shopcarts """

--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -33,6 +33,16 @@ class Shopcart(object):
         """ Deletes a Shopcart in the database """
         Shopcart.__data.remove(self)
 
+    def serialize(self):
+        """ Serializes a shopcart into a dictionary """
+        return {"uid": self.uid, "products": self.products }
+
+    def get_available_id(self):
+        uid=0
+        while self.find(uid):
+            uid +=1
+        return uid
+
     @staticmethod
     def all():
         """ Query that returns all Shopcarts """

--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -39,19 +39,20 @@ class Shopcart(object):
 
     def deserialize(self,data):
         """ Deserializes a shopcart from a dictionary """
+
+        #Just a product id
+        if type( data ) == int:
+            self.products = self.__validate_products( data  )
+            return
         
+        # A {'products': {'prod':quant} } ** JSON.DUMP MAKES KEYS TO STR
         if type( data ) != dict :
             raise DataValidationError('Invalid shopcart: body of request contained bad or no data')
-
-        if "uid" in data.keys():
-            try:
-                self.uid = int(data['uid'])
-            except ValueError :
-                raise DataValidationError('ERROR: %s has an invalid format for user id'% data['uid'])
 
         if "products" in data.keys():
             try:
                 if type( data['products'] ) == dict:
+                    # ** JSON.DUMP MAKES KEYS TO STR
                     prods = { int(p):int(q) for (p,q) in data['products'].items() }
                 else:
                     prods = int( data['products'] )
@@ -92,7 +93,7 @@ class Shopcart(object):
             return {products[0]:products[1]}
 
         # Just a Product id, set default quantity to 1
-        if type(products) == int: 
+        if type(products) == int and products >= 0: 
             return {products:1}
 
         if type(products) != dict : 
@@ -103,5 +104,3 @@ class Shopcart(object):
              all( (isinstance(q,int) and (q > 0)) for q in products.values() ) ):
             return products
 
-        #Products not valid
-        raise DataValidationError("ERROR: Data Validation error\nInvalid format for products")

--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -39,9 +39,15 @@ class Shopcart(object):
 
     def deserialize(self,data):
         """ Deserializes a shopcart from a dictionary """
-        self.uid = self.get_available_id()
+        
         if type( data ) != dict :
             raise DataValidationError('Invalid shopcart: body of request contained bad or no data')
+
+        if "uid" in data.keys():
+            try:
+                self.uid = int(data['uid'])
+            except ValueError :
+                raise DataValidationError('ERROR: %s has an invalid format for user id'% data['uid'])
 
         if "products" in data.keys():
             try:
@@ -50,7 +56,7 @@ class Shopcart(object):
                 else:
                     prods = int( data['products'] )
                 self.products = self.__validate_products( prods )
-            except ValueError as e:
+            except ValueError :
                 raise DataValidationError('ERROR: %s has an invalid format for products'% data['products'])
         return
 

--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -39,11 +39,6 @@ class Shopcart(object):
 
     def deserialize(self,data):
         """ Deserializes a shopcart from a dictionary """
-
-        #Just a product id
-        if type( data ) == int:
-            self.products = self.__validate_products( data  )
-            return
         
         # A {'products': {'prod':quant} } ** JSON.DUMP MAKES KEYS TO STR
         if type( data ) != dict :
@@ -58,6 +53,8 @@ class Shopcart(object):
                     prods = int( data['products'] )
                 self.products = self.__validate_products( prods )
             except ValueError :
+                raise DataValidationError('ERROR: %s has an invalid format for products'% data['products'])
+            except TypeError :
                 raise DataValidationError('ERROR: %s has an invalid format for products'% data['products'])
         return
 

--- a/server.py
+++ b/server.py
@@ -36,22 +36,25 @@ def get_shopcarts(id):
 ######################################################################
 # Create a Shopcart
 ######################################################################
-@app.route('/shopcarts/<int:id>', methods=['PUT'])
+@app.route('/shopcarts/<int:id>', methods=['POST'])
 def create_shopcart(id):
-    """Creates a shopcart and saves it to database
-        POST Request accepts data as: 
-        - id + prod id (sets default to 1)
-        - id + {prod:quant}
-    """
-    # if cart = Shopcart.find(id):
-        # Not clear on what to do here
-    #     return 
-    cart = Shopcart()
+    """Creates a shopcart and saves it to database"""
+    cart = Shopcart.find(id)
+    if cart:
+        message = jsonify({ 'error' : 'Shopcart for user %s already exits' % str(id) })
+        rc = status.HTTP_409_CONFLICT
+        return make_response(message,rc)
+
+    # Create the Cart
+    cart = Shopcart(id)
+    #Validate correct data
     try:
         cart.deserialize(  request.get_json() )
     except DataValidationError as e:
-        message = {'error': e.args[0]}
+        message = { 'error': e.args[0] }
         return jsonify(message), status.HTTP_400_BAD_REQUEST
+
+    # If correct save it and return object
     cart.save()
     message = cart.serialize()
     location_url = url_for('get_shopcarts', id = int( cart.uid ), _external=True)    

--- a/server.py
+++ b/server.py
@@ -36,18 +36,22 @@ def get_shopcarts(id):
 ######################################################################
 # Create a Shopcart
 ######################################################################
-@app.route('/shopcarts', methods=['POST'])
-def create_shopcart():
+@app.route('/shopcarts/<int:id>', methods=['PUT'])
+def create_shopcart(id):
     """Creates a shopcart and saves it to database
-        POST Request accepts data as: no id (Finds the first available and assigns it)
+        POST Request accepts data as: 
+        - id + prod id (sets default to 1)
+        - id + {prod:quant}
     """
+    # if cart = Shopcart.find(id):
+        # Not clear on what to do here
+    #     return 
     cart = Shopcart()
     try:
         cart.deserialize(  request.get_json() )
     except DataValidationError as e:
         message = {'error': e.args[0]}
         return jsonify(message), status.HTTP_400_BAD_REQUEST
-
     cart.save()
     message = cart.serialize()
     location_url = url_for('get_shopcarts', id = int( cart.uid ), _external=True)    

--- a/server.py
+++ b/server.py
@@ -36,9 +36,16 @@ def get_shopcarts(id):
 ######################################################################
 # Create a Shopcart
 ######################################################################
-@app.route('/shopcarts/<int:id>', methods=['POST'])
-def create_shopcart(id):
+@app.route('/shopcarts', methods=['POST'])
+def create_shopcart():
     """Creates a shopcart and saves it to database"""
+    data = request.get_json()
+    try :
+        id = data['uid']
+    except KeyError :
+        message = { 'error': 'POST needs a user id' }
+        return jsonify(message), status.HTTP_400_BAD_REQUEST
+
     cart = Shopcart.find(id)
     if cart:
         message = jsonify({ 'error' : 'Shopcart for user %s already exits' % str(id) })
@@ -49,7 +56,7 @@ def create_shopcart(id):
     cart = Shopcart(id)
     #Validate correct data
     try:
-        cart.deserialize(  request.get_json() )
+        cart.deserialize(  data )
     except DataValidationError as e:
         message = { 'error': e.args[0] }
         return jsonify(message), status.HTTP_400_BAD_REQUEST

--- a/server.py
+++ b/server.py
@@ -54,10 +54,14 @@ def create_shopcart():
     try:
         prods ={}
         if 'products' in dat.keys():
-            if type(dat['products']) == dict:
-                prods = { int(p):int(q) for (p,q) in dat['products'].items() }
-            else:
-                prods = dat['products']
+            try:
+                if type(dat['products']) == dict:
+                    prods = { int(p):int(q) for (p,q) in dat['products'].items() }
+                else:
+                    prods = dat['products']
+            except ValueError as e:
+                raise DataValidationError('ERROR: %s has an invalid format for products'% dat['products'])
+
         if 'uid' in dat.keys():
             uid = dat['uid']
         else:

--- a/server.py
+++ b/server.py
@@ -36,45 +36,23 @@ def get_shopcarts(id):
 ######################################################################
 # Create a Shopcart
 ######################################################################
-@app.route('/shopcarts/', methods=['POST'])
+@app.route('/shopcarts', methods=['POST'])
 def create_shopcart():
+    """Creates a shopcart and saves it to database
+        POST Request accepts data as: no id (Finds the first available and assigns it)
     """
-        Creates a shopcart and saves it to database
-        POST Request accepts data as:
-            - no id (Finds the first available and assigns it)
-            - id 
-            - id + one product id (Model sets quant to 1)
-            - id + dictionary of {prod_id:quant}
-    """
-    dat= request.get_json()
-    if Shopcart.find( dat['uid'] ):
-        message = { 'ERROR' : 'Shopcart with id: %s is in Database' % str(id) }
-        return make_response(jsonify(message), status.HTTP_400_BAD_REQUEST )
-    
+    cart = Shopcart()
     try:
-        prods ={}
-        if 'products' in dat.keys():
-            try:
-                if type(dat['products']) == dict:
-                    prods = { int(p):int(q) for (p,q) in dat['products'].items() }
-                else:
-                    prods = dat['products']
-            except ValueError as e:
-                raise DataValidationError('ERROR: %s has an invalid format for products'% dat['products'])
-
-        if 'uid' in dat.keys():
-            uid = dat['uid']
-        else:
-            uid = Shopcart().get_available_id()
-        cart = Shopcart(uid, prods )
+        cart.deserialize(  request.get_json() )
     except DataValidationError as e:
-        return make_response( jsonify(e.args[0]) , status.HTTP_400_BAD_REQUEST )
+        message = {'error': e.args[0]}
+        return jsonify(message), status.HTTP_400_BAD_REQUEST
 
     cart.save()
     message = cart.serialize()
-    location_url = url_for('get_shopcarts', id=cart.uid, _external=True)
-    return jsonify(message), status.HTTP_201_CREATED, {'Location': location_url}
-
+    location_url = url_for('get_shopcarts', id = int( cart.uid ), _external=True)    
+    return make_response(jsonify(message), status.HTTP_201_CREATED, { 'Location': location_url })
+    
 if __name__ == "__main__":
     # dummy data for server testing
     app.run(host='0.0.0.0', port=int(PORT), debug=DEBUG)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,8 @@ import unittest
 import json
 from flask_api import status
 import server
+from models.shopcart import Shopcart
+from models.dataerror import DataValidationError
 
 class TestServer(unittest.TestCase):
     """ Shopcarts Server Tests """
@@ -9,6 +11,7 @@ class TestServer(unittest.TestCase):
         self.app = server.app.test_client()
         server.Shopcart(1).save()
         server.Shopcart(2).save()
+        server.Shopcart().save()
 
     def tearDown(self):
         server.Shopcart.remove_all()
@@ -36,6 +39,81 @@ class TestServer(unittest.TestCase):
         self.assertEqual( resp.status_code, status.HTTP_404_NOT_FOUND )
         data = json.loads(resp.data.decode('utf8'))
         self.assertEqual (data['error'], 'Shopcart with id: 3 was not found')
+
+    def test_create_an_existing_shopcart(self):
+        """ Create an existing shopcart PUT request"""
+        # Get an existing shopcart
+        cart = Shopcart.find(1)
+        self.assertIsNotNone(cart)
+        # add this shopcart
+        new_shopcart = {'uid': cart.uid }
+        data = json.dumps(new_shopcart)
+        resp = self.app.post('/shopcarts/', data=data, content_type='application/json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_shopcart(self):
+        """ Create a shopcart PUT request"""
+        #Check for exists
+        cart = Shopcart.find(5)
+        self.assertIsNone(cart)
+        # add a new shopcart 
+        new_shopcart = {'uid': 5 }
+        data = json.dumps(new_shopcart)
+        resp = self.app.post('/shopcarts/', data=data, content_type='application/json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        
+        # Make sure location header is set
+        location = resp.headers.get('Location', None)
+        self.assertIsNotNone(location)
+
+        # Check the data is correct
+        new_json = json.loads(resp.data.decode('utf8'))
+        self.assertEqual(new_json['uid'], 5)
+
+    def test_create_shopcart_prods(self):
+        """ Create a shopcart with many products PUT request"""
+        
+        # add a new shopcart with many products
+        new_shopcart = {'uid': 5 , 'products':{8:13,21:34}}
+        data = json.dumps(new_shopcart)
+        resp = self.app.post('/shopcarts/', data=data, content_type='application/json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        
+        # Make sure location header is set
+        location = resp.headers.get('Location', None)
+        self.assertIsNotNone(location)
+
+        # Check the data is correct
+        new_json = json.loads(resp.data.decode('utf8'))
+        self.assertEqual(new_json, json.loads(data))
+
+    # def test_create_shopcart_one_prods(self):
+    #     """ Create a shopcart with one product id PUT request"""
+        
+    #     # add a new shopcart with one products
+    #     new_shopcart = {'uid': 5 , 'products':21}
+    #     data = json.dumps(new_shopcart)
+    #     resp = self.app.post('/shopcarts/', data=data, content_type='application/json')
+    #     self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        
+    #     # Make sure location header is set
+    #     location = resp.headers.get('Location', None)
+    #     self.assertIsNotNone(location)
+
+    #     # Check the data is correct
+    #     new_json = json.loads(resp.data.decode('utf8'))
+    #     data=json.loads( json.dumps( {'uid': 5 , 'products':{21:1} }) )
+    #     self.assertEqual(new_json, data)
+
+    # def test_create_shopcart_invalid_prods(self):
+    #     """ Create a shopcart with invalid products PUT request"""
+    #     # add a new shopcart with many products
+    #     new_shopcart = {'uid': 5 , 'products':{'prod1':13}}
+    #     data = json.dumps(new_shopcart)
+    #     resp = self.app.post('/shopcarts/', data=data, content_type='application/json')
+    #     self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -87,33 +87,31 @@ class TestServer(unittest.TestCase):
         new_json = json.loads(resp.data.decode('utf8'))
         self.assertEqual(new_json, json.loads(data))
 
-    # def test_create_shopcart_one_prods(self):
-    #     """ Create a shopcart with one product id PUT request"""
+    def test_create_shopcart_one_prods(self):
+        """ Create a shopcart with one product id PUT request"""
         
-    #     # add a new shopcart with one products
-    #     new_shopcart = {'uid': 5 , 'products':21}
-    #     data = json.dumps(new_shopcart)
-    #     resp = self.app.post('/shopcarts/', data=data, content_type='application/json')
-    #     self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        # add a new shopcart with one products
+        new_shopcart = {'uid': 5 , 'products':21}
+        data = json.dumps(new_shopcart)
+        resp = self.app.post('/shopcarts/', data=data, content_type='application/json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         
-    #     # Make sure location header is set
-    #     location = resp.headers.get('Location', None)
-    #     self.assertIsNotNone(location)
+        # Make sure location header is set
+        location = resp.headers.get('Location', None)
+        self.assertIsNotNone(location)
 
-    #     # Check the data is correct
-    #     new_json = json.loads(resp.data.decode('utf8'))
-    #     data=json.loads( json.dumps( {'uid': 5 , 'products':{21:1} }) )
-    #     self.assertEqual(new_json, data)
+        # Check the data is correct
+        new_json = json.loads(resp.data.decode('utf8'))
+        data=json.loads( json.dumps( {'uid': 5 , 'products':{21:1} }) )
+        self.assertEqual(new_json, data)
 
-    # def test_create_shopcart_invalid_prods(self):
-    #     """ Create a shopcart with invalid products PUT request"""
-    #     # add a new shopcart with many products
-    #     new_shopcart = {'uid': 5 , 'products':{'prod1':13}}
-    #     data = json.dumps(new_shopcart)
-    #     resp = self.app.post('/shopcarts/', data=data, content_type='application/json')
-    #     self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+    def test_create_shopcart_invalid_prods(self):
+        """ Create a shopcart with invalid products PUT request"""
+        # add a new shopcart with many products
+        new_shopcart = {'uid': 5 , 'products':{'prod1':13}}
+        data = json.dumps(new_shopcart)
+        resp = self.app.post('/shopcarts/', data=data, content_type='application/json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -42,8 +42,8 @@ class TestServer(unittest.TestCase):
         """ Create an empty shopcart POST on shopcarts"""
         # add a new shopcart 
         n_cart = len(server.Shopcart.all())
-        prods = {}
-        resp = self.app.post('/shopcarts/3', data=json.dumps(prods), content_type='application/json')
+        cart = {'uid': 3 }
+        resp = self.app.post('/shopcarts', data=json.dumps(cart), content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         
         # Make sure location header is set
@@ -56,24 +56,23 @@ class TestServer(unittest.TestCase):
 
     def test_create_shopcart_invalid_data(self):
         """ Create a cart with invalid data"""
-        prods = 'prod1'
-        resp = self.app.post('/shopcarts/3', data=json.dumps(prods), content_type='application/json')
+        cart = {'uid': 3 , "products":'prod1'}
+        resp = self.app.post('/shopcarts', data=json.dumps(cart), content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         
-        prods = -12
-        resp = self.app.post('/shopcarts/3', data=json.dumps(prods), content_type='application/json')
+        cart= {'uid': 3 , "products":-12}
+        resp = self.app.post('/shopcarts', data=json.dumps(cart), content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         
-        prods =  []
-        resp = self.app.post('/shopcarts/3', data=json.dumps(prods), content_type='application/json')
+        cart= {'uid': 3 , 'products':[]}
+        resp = self.app.post('/shopcarts', data=json.dumps(cart), content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         
-
     def test_create_shopcart_with_a_prod(self):
         """ Create a cart uid 3 with a product id 5"""
         n_cart = len(server.Shopcart.all())
-        prods =  5
-        resp = self.app.post('/shopcarts/3', data=json.dumps(prods), content_type='application/json')
+        cart= {'uid': 3 , "products":5}
+        resp = self.app.post('/shopcarts', data=json.dumps(cart), content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         location = resp.headers.get('Location', None)
         self.assertIsNotNone(location)
@@ -82,36 +81,19 @@ class TestServer(unittest.TestCase):
         self.assertEqual( data['products'] , {'5':1} )
         self.assertEqual(len(server.Shopcart.all()),n_cart+1 )
 
-    def test_create_shopcart_one_prods(self):
-        """ Create a shopcart with one product id"""        
-        # add a new shopcart with one product
-        n_cart = len(server.Shopcart.all())
-        cart = {'products':21}
-        data = json.dumps(cart)
-        resp = self.app.post('/shopcarts/3', data=data, content_type='application/json')
-        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        location = resp.headers.get('Location', None)
-        self.assertIsNotNone(location)
-        self.assertIn('/shopcarts',location  )
-        # Check the data is correct
-        new_json = json.loads(resp.data.decode('utf8'))
-        self.assertEqual(new_json['products'], {'21':1} )
-        #Actually saved
-        self.assertEqual(len(server.Shopcart.all()),n_cart+1 )
-
     def test_create_shopcart_prods(self):
         """ Create a shopcart with many products"""
         n_cart = len(server.Shopcart.all())
         # add a new shopcart with many products
-        new_shopcart = { "products": { 8:13 , 21:34 } }
+        new_shopcart = {"uid":3 , "products": { 8:13 , 21:34 } }
         data = json.dumps( new_shopcart )
-        resp = self.app.post('/shopcarts/3', data=data, content_type='application/json')
+        resp = self.app.post('/shopcarts', data=data, content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         
         # Make sure location header is set
         location = resp.headers.get('Location', None)
         self.assertIsNotNone(location)
-        self.assertIn('/shopcarts/3',location  )
+        self.assertIn('/shopcarts',location  )
 
         # Check the data is correct
         new_json = json.loads(resp.data.decode('utf8'))
@@ -120,22 +102,30 @@ class TestServer(unittest.TestCase):
 
     def test_create_shopcart_invalid_prods(self):
         """ Create a shopcart with invalid products """
-        # add a new shopcart with many products
-        new_shopcart = { 'products': { 'prod1':'13'} }
+        new_shopcart = {'uid':3, 'products': { 'prod1':'13'} }
         data = json.dumps(new_shopcart)
-        resp = self.app.post('/shopcarts/3', data=data, content_type='application/json')
+        resp = self.app.post('/shopcarts', data=data, content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_shopcart_that_exists(self):
         """ Create a shopcart that exists"""
-        # 
         n_cart = len(server.Shopcart.all())
         cart = server.Shopcart.find(1)
         self.assertIsNotNone(cart)
         data = json.dumps(cart.serialize())
-        resp = self.app.post('/shopcarts/' + str(cart.uid), data=data, content_type='application/json')
+        resp = self.app.post('/shopcarts', data=data, content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_409_CONFLICT)
         self.assertEqual(n_cart, len(server.Shopcart.all()) )
+
+    def test_create_without_uid(self):
+        """ Create a shopcart without id"""
+        n_cart = len(server.Shopcart.all())
+        cart = {}
+        data = json.dumps(cart)
+        resp = self.app.post('/shopcarts', data=data, content_type='application/json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(n_cart, len(server.Shopcart.all()) )
+
 
 
 if __name__ == '__main__':

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,8 +2,6 @@ import unittest
 import json
 from flask_api import status
 import server
-# from models.shopcart import Shopcart
-# from models.dataerror import DataValidationError
 
 class TestServer(unittest.TestCase):
     """ Shopcarts Server Tests """
@@ -43,61 +41,79 @@ class TestServer(unittest.TestCase):
     def test_create_shopcart(self):
         """ Create an empty shopcart POST on shopcarts"""
         # add a new shopcart 
-        cart = {'uid':3}
-        resp = self.app.post('/shopcarts', data=json.dumps(cart), content_type='application/json')
+        n_cart = len(server.Shopcart.all())
+        cart = {'uid':3 }
+        resp = self.app.put('/shopcarts/3', data=json.dumps(cart), content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         
         # Make sure location header is set
         location = resp.headers.get('Location', None)
         self.assertIsNotNone(location)
-        # data = json.loads(resp.data.decode('utf8'))
-        # self.assertEqual(location, data['Location'] )
+        data = json.loads(resp.data.decode('utf8'))
+        self.assertIn('/shopcarts/3',location  )
+        #Actually saved
+        self.assertEqual(len(server.Shopcart.all()),n_cart+1 )
 
     def test_create_shopcart_invalid_data(self):
         """ Create a cart with invalid data"""
         # add a new shopcart 
-        prods = [1]
-        resp = self.app.post('/shopcarts', data=json.dumps(prods), content_type='application/json')
+        new = {'uid':'one'}
+        resp = self.app.put('/shopcarts/3', data=json.dumps(new), content_type='application/json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        
+    def test_create_shopcart_invalid_prod_data(self):
+        """ Create a cart with invalid  product data"""
+        # add a new shopcart 
+        prods = 3
+        resp = self.app.put('/shopcarts/3', data=json.dumps(prods), content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         
     def test_create_shopcart_one_prods(self):
-        """ Create a shopcart with one product id PUT request"""        
+        """ Create a shopcart with one product id POST request"""        
         # add a new shopcart with one product
-        cart = {'products':21}
+        n_cart = len(server.Shopcart.all())
+        cart = {'uid':3, 'products':21}
         data = json.dumps(cart)
-        resp = self.app.post('/shopcarts', data=data, content_type='application/json')
+        resp = self.app.put('/shopcarts/1', data=data, content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         location = resp.headers.get('Location', None)
         self.assertIsNotNone(location)
-
+        self.assertIn('/shopcarts/3',location  )
         # Check the data is correct
         new_json = json.loads(resp.data.decode('utf8'))
         self.assertEqual(new_json['products'], {'21':1} )
+        #Actually saved
+        self.assertEqual(len(server.Shopcart.all()),n_cart+1 )
+
 
     def test_create_shopcart_prods(self):
-        """ Create a shopcart with many products PUT request"""
-        
+        """ Create a shopcart with many products POST request"""
+        n_cart = len(server.Shopcart.all())
         # add a new shopcart with many products
-        new_shopcart = { "products": { 8:13 , 21:34 } }
+        new_shopcart = { 'uid':3, "products": { 8:13 , 21:34 } }
         data = json.dumps( new_shopcart )
-        resp = self.app.post('/shopcarts', data=data, content_type='application/json')
+        resp = self.app.put('/shopcarts/3', data=data, content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         
         # Make sure location header is set
         location = resp.headers.get('Location', None)
         self.assertIsNotNone(location)
+        self.assertIn('/shopcarts/3',location  )
 
         # Check the data is correct
         new_json = json.loads(resp.data.decode('utf8'))
         self.assertEqual(new_json['products'], {"8":13,"21":34})
+        self.assertEqual(len(server.Shopcart.all()),n_cart+1 )
+
 
     def test_create_shopcart_invalid_prods(self):
-        """ Create a shopcart with invalid products PUT request"""
+        """ Create a shopcart with invalid products POST request"""
         # add a new shopcart with many products
-        new_shopcart = { 'products': { 'prod1':'13'} }
+        new_shopcart = { 'uid':3, 'products': { 'prod1':'13'} }
         data = json.dumps(new_shopcart)
-        resp = self.app.post('/shopcarts', data=data, content_type='application/json')
+        resp = self.app.put('/shopcarts/3', data=data, content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
-        
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_shopcart.py
+++ b/tests/test_shopcart.py
@@ -182,16 +182,6 @@ class TestShopcart(unittest.TestCase):
         cart.delete()
         self.assertEqual( len(Shopcart.all()), 0)
 
-    def test_get_an_available_shopcart_id(self):
-        """ Test to get an available id """
-        cart = Shopcart(0)
-        cart.save()
-        self.assertEqual( Shopcart().get_available_id(), 1)
-        cart = Shopcart(1)
-        cart.save()
-        cart = Shopcart(2)
-        cart.save()
-        self.assertEqual( Shopcart().get_available_id(), 3)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_shopcart.py
+++ b/tests/test_shopcart.py
@@ -182,6 +182,16 @@ class TestShopcart(unittest.TestCase):
         cart.delete()
         self.assertEqual( len(Shopcart.all()), 0)
 
+    def test_get_an_available_shopcart_id(self):
+        """ Test to get an available id """
+        cart = Shopcart(0)
+        cart.save()
+        self.assertEqual( Shopcart().get_available_id(), 1)
+        cart = Shopcart(1)
+        cart.save()
+        cart = Shopcart(2)
+        cart.save()
+        self.assertEqual( Shopcart().get_available_id(), 3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Creates a shopcart and saves it to database from a `POST` request on `/shopcarts/id`
    - Request accepts data as:
            - Single product id as int
            - dictionary of {prod_id:quant}

- Created a serializing method in shopcarts model to pass to response.
- Created a deserializing method in shopcarts model to get response.
**NOTE**: All appropriate TESTS are included.