### PR TITLE
Delete a shopcart

### DIFF
--- a/server.py
+++ b/server.py
@@ -32,6 +32,22 @@ def get_shopcarts(id):
 
     return jsonify(message), rc
 
+######################################################################
+# DELETE A SHOPCART
+######################################################################
+@app.route('/shopcarts/<int:id>', methods=['DELETE'])
+def delete_shopcarts(id):
+    """
+    Delete a Shopcart
+    This endpoint will delete a Shopcart based on the id specified in the path
+    """
+    cart = Shopcart.find(id)
+    
+    if cart:
+        cart.delete()
+
+    return make_response('', status.HTTP_204_NO_CONTENT)
+
 
 if __name__ == "__main__":
     # dummy data for server testing

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,6 +36,24 @@ class TestServer(unittest.TestCase):
         self.assertEqual( resp.status_code, status.HTTP_404_NOT_FOUND )
         data = json.loads(resp.data.decode('utf8'))
         self.assertEqual (data['error'], 'Shopcart with id: 3 was not found')
+    
+    def test_delete_shopcart(self):
+        """ Delete a Shopcart that exists """
+        cart_count = len(server.Shopcart.all())
+        resp = self.app.delete('/shopcarts/1')
+
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(len(resp.data), 0)
+        self.assertEqual(len(server.Shopcart.all()), cart_count - 1)
+    
+    def test_delete_nonexistent_shopcart(self):
+        """ Delete a Shopcart that doesn't exist """
+        cart_count = len(server.Shopcart.all())
+        resp = self.app.delete('/shopcarts/5')
+
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(len(resp.data), 0)
+        self.assertEqual(len(server.Shopcart.all()), cart_count)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds the RESTful api to delete a shopcart at `/shopcarts/<id>`.

This will return a `204` whether the shopcart previously existed or not.

All tests pass and code coverage for `server.py` is increased.