### PR TITLE
Delete <productid> from shopcart

### DIFF
--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -33,6 +33,10 @@ class Shopcart(object):
         """ Deletes a Shopcart in the database """
         Shopcart.__data.remove(self)
 
+    def delete_product(self, pid):
+        """ Removes a Product entirely from a Shopcart """
+        self.products.pop(pid, None)
+
     @staticmethod
     def all():
         """ Query that returns all Shopcarts """
@@ -60,15 +64,15 @@ class Shopcart(object):
             return {}
 
         #Not None
-        # Tuple of product, quantity 
-        if type(products) == tuple  and len(products)==2 and all(isinstance(pq,int) for pq in products): 
+        # Tuple of product, quantity
+        if type(products) == tuple  and len(products)==2 and all(isinstance(pq,int) for pq in products):
             return {products[0]:products[1]}
 
         # Just a Product id, set default quantity to 1
-        if type(products) == int: 
+        if type(products) == int:
             return {products:1}
 
-        if type(products) != dict : 
+        if type(products) != dict :
             raise DataValidationError("ERROR: Data Validation error\nInvalid format for products")
 
         # Products is a dict of proper tuples

--- a/server.py
+++ b/server.py
@@ -17,7 +17,7 @@ def index():
                    version='1.0',
                    description= 'This is the REST API Service for the shopcarts.'), status.HTTP_200_OK
 
-
+######################################################################
 # RETRIEVE A SHOPCART
 ######################################################################
 @app.route('/shopcarts/<int:id>', methods=['GET'])
@@ -32,6 +32,16 @@ def get_shopcarts(id):
 
     return jsonify(message), rc
 
+
+######################################################################
+# DELETE A PRODUCT FROM A SHOPCART
+######################################################################
+@app.route('/shopcarts/<int:uid>/products/<int:pid>', methods=['DELETE'])
+def delete_product(uid, pid):
+    cart = Shopcart.find(uid)
+    if cart:
+        cart.products.pop(pid, None)
+    return make_response('', status.HTTP_204_NO_CONTENT)
 
 if __name__ == "__main__":
     # dummy data for server testing

--- a/server.py
+++ b/server.py
@@ -40,7 +40,7 @@ def get_shopcarts(id):
 def delete_product(uid, pid):
     cart = Shopcart.find(uid)
     if cart:
-        cart.products.pop(pid, None)
+        cart.delete_product(pid)
     return make_response('', status.HTTP_204_NO_CONTENT)
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,6 +9,8 @@ class TestServer(unittest.TestCase):
         self.app = server.app.test_client()
         server.Shopcart(1).save()
         server.Shopcart(2).save()
+        # uid 3 is used in test_get_nonexistent_shopcart
+        server.Shopcart(4, { 5 : 7, 13 : 21, 34 : 55 }).save()
 
     def tearDown(self):
         server.Shopcart.remove_all()
@@ -36,6 +38,22 @@ class TestServer(unittest.TestCase):
         self.assertEqual( resp.status_code, status.HTTP_404_NOT_FOUND )
         data = json.loads(resp.data.decode('utf8'))
         self.assertEqual (data['error'], 'Shopcart with id: 3 was not found')
+
+    def test_delete_a_product_from_shopcart(self):
+        """ Test Delete a Product From A Shopcart """
+        # Delete products with ID of 5 from cart 1
+        resp = self.app.delete('/shopcarts/4/products/5')
+        self.assertEqual( resp.status_code, status.HTTP_204_NO_CONTENT )
+        cart = server.Shopcart.find(4)
+        self.assertEqual( (5 in cart.products), False)
+
+    def test_delete_nonexistent_product_from_shopcart(self):
+        """ Test Delete a Nonexistent Product From A Shopcart """
+        resp = self.app.delete('/shopcarts/2/products/5')
+        self.assertEqual( resp.status_code, status.HTTP_204_NO_CONTENT )
+        cart = server.Shopcart.find(2)
+        self.assertEqual( (5 in cart.products), False)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_shopcart.py
+++ b/tests/test_shopcart.py
@@ -41,7 +41,7 @@ class TestShopcart(unittest.TestCase):
         # Passing a double
         with self.assertRaises(DataValidationError):
             shopcart = Shopcart(1,2.0)
-            
+
     def test_set_is_invalid_product(self):
         """Test for not allowing sets in products"""
         # Passing a set
@@ -81,7 +81,7 @@ class TestShopcart(unittest.TestCase):
         self.assertTrue( len(shopcart.products) > 0)
         self.assertEqual( shopcart.products , {5:1} )
 
-        # Creating a valid dictionary 
+        # Creating a valid dictionary
         shopcart = Shopcart(0, {5:7,13:21,34:55 } )
         self.assertEqual( shopcart.products , {5:7,13:21,34:55 } )
 
@@ -93,7 +93,7 @@ class TestShopcart(unittest.TestCase):
         #Correct Type
         s = shopcarts[0]
         self.assertTrue( type(s.products) == dict)
-        
+
         #Correct Length
         self.assertEqual( len(s.products) , 3)
 
@@ -105,7 +105,7 @@ class TestShopcart(unittest.TestCase):
         s=shopcarts[0]
         self.assertEqual( s.uid ,7 )
         self.assertEqual( len(s.products) , 0 )
-        
+
         # Adding product 21 with quant 34
         s.add_product( 21,34 )
         #There's only one product
@@ -113,7 +113,7 @@ class TestShopcart(unittest.TestCase):
         # It's the correct one with correct quant
         self.assertEqual( s.products[21] , 34 )
 
-        # Adding a second 
+        # Adding a second
         s.add_product( 34, 55 )
         #There's two  products
         self.assertEqual( len(s.products) ,2 )
@@ -128,7 +128,7 @@ class TestShopcart(unittest.TestCase):
         s=shopcarts[0]
         self.assertEqual( s.uid ,21 )
         self.assertEqual( len(s.products) , 0 )
-        
+
         # Adding product 21.5
         with self.assertRaises(DataValidationError):
             s.add_product( 21.5 )
@@ -153,7 +153,7 @@ class TestShopcart(unittest.TestCase):
         self.assertEqual(shopcarts[0].uid, 1)
         self.assertEqual(shopcarts[1].uid, 2)
         self.assertEqual(shopcarts[2].uid, 3)
-    
+
     def test_find_a_shopcart(self):
         """ Find a shopcart by uid """
         Shopcart(2).save()
@@ -163,7 +163,7 @@ class TestShopcart(unittest.TestCase):
 
         self.assertEqual(cart.uid, 5)
         self.assertEqual(len(cart.products), 0)
-    
+
     def test_find_shopcart_that_doesnt_exist(self):
         """ Try to find a non-existant Shopcart """
         Shopcart(2).save()
@@ -182,6 +182,11 @@ class TestShopcart(unittest.TestCase):
         cart.delete()
         self.assertEqual( len(Shopcart.all()), 0)
 
+    def test_delete_products_from_shopcart(self):
+        cart = Shopcart(1, { 5 : 7})
+        cart.save()
+        cart.delete_product(5)
+        self.assertEqual( len(cart.products), 0 )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implemented as a `DELETE` request to `/shopcarts/<uid>/products/<pid>`

I delete all products with `<pid>` in the shopcart with `<uid`>. So, if there is a product with pid 1 and quantity 5, I delete all 5 of those products from the shopcart. 

This was straightforward using a dictionary by just using a simple `pop` method with a specified key, which is the `pid` in our case. 