### PR TITLE
List All Shopcarts 

### DIFF
--- a/server.py
+++ b/server.py
@@ -93,6 +93,16 @@ def delete_product(uid, pid):
         cart.delete_product(pid)
     return make_response('', status.HTTP_204_NO_CONTENT)
 
+######################################################################
+# List all Shopcarts
+######################################################################
+@app.route('/shopcarts', methods=['GET'])
+def get_all_shopcarts():
+    carts = Shopcart.all()
+    message = [cart.serialize() for cart in carts]
+    rc = status.HTTP_200_OK
+    return jsonify(message), rc
+
 if __name__ == "__main__":
     # dummy data for server testing
     app.run(host='0.0.0.0', port=int(PORT), debug=DEBUG)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -161,6 +161,12 @@ class TestServer(unittest.TestCase):
         cart = server.Shopcart.find(2)
         self.assertEqual( (5 in cart.products), False)
 
+    def test_get_all_shopcart(self):
+        """ List All Shopcarts """
+        resp = self.app.get('/shopcarts')
+        self.assertEqual( resp.status_code, status.HTTP_200_OK )
+        carts = json.loads(resp.data.decode('utf8'))
+        self.assertEqual( len(carts), 3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implemented as a `GET` request on `/shopcarts`, where I call Shopcart's `all()` method, serialize each cart, then jsonify the list. 

Running nosetests should have 30 tests pass