### PR TITLE
Prune empty shopcarts

### DIFF
--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -82,6 +82,11 @@ class Shopcart(object):
         return None
 
     @staticmethod
+    def prune():
+        """ Delete empty shopcarts """
+        Shopcart.__data = [cart for cart in Shopcart.__data if cart.products]
+
+    @staticmethod
     def __validate_products(products):
         """ Validates products or raises an error"""
         # Product is none so set an empty list

--- a/server.py
+++ b/server.py
@@ -148,7 +148,7 @@ def get_all_shopcarts():
 ######################################################################
 # Prune empty Shopcarts
 ######################################################################
-@app.route('/shopcarts/prune', methods=['PUT'])
+@app.route('/shopcarts/prune', methods=['DELETE'])
 def prune_empty_shopcarts():
     Shopcart.prune()
     return make_response('', status.HTTP_204_NO_CONTENT)

--- a/server.py
+++ b/server.py
@@ -103,6 +103,14 @@ def get_all_shopcarts():
     rc = status.HTTP_200_OK
     return jsonify(message), rc
 
+######################################################################
+# Prune empty Shopcarts
+######################################################################
+@app.route('/shopcarts/prune', methods=['PUT'])
+def prune_empty_shopcarts():
+    Shopcart.prune()
+    return make_response('', status.HTTP_204_NO_CONTENT)
+
 if __name__ == "__main__":
     # dummy data for server testing
     app.run(host='0.0.0.0', port=int(PORT), debug=DEBUG)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -167,6 +167,13 @@ class TestServer(unittest.TestCase):
         self.assertEqual( resp.status_code, status.HTTP_200_OK )
         carts = json.loads(resp.data.decode('utf8'))
         self.assertEqual( len(carts), 3)
+    
+    def test_prune_empty_shopcarts(self):
+        """ Prune empty shopcarts """
+        resp = self.app.put('/shopcarts/prune')
+
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(len(server.Shopcart.all()), 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -247,7 +247,7 @@ class TestServer(unittest.TestCase):
     
     def test_prune_empty_shopcarts(self):
         """ Prune empty shopcarts """
-        resp = self.app.put('/shopcarts/prune')
+        resp = self.app.delete('/shopcarts/prune')
 
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(len(server.Shopcart.all()), 1)

--- a/tests/test_shopcart.py
+++ b/tests/test_shopcart.py
@@ -188,5 +188,17 @@ class TestShopcart(unittest.TestCase):
         cart.delete_product(5)
         self.assertEqual( len(cart.products), 0 )
 
+    def test_shopcarts_are_pruned(self):
+        """ Test empty shopcarts are pruned """
+        Shopcart(1).save()
+        Shopcart(2).save()
+        Shopcart(3, { 5 : 7}).save()
+
+        Shopcart.prune()
+        
+        self.assertEqual(len(Shopcart.all()), 1)
+
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This will delete all empty shopcarts (no products) via a `PUT` request to `shopcarts/prune`. All tests passing for model and server and kept code coverage the same.

I returned the same type of response as a delete `HTTP_204_NO_CONTENT` as this is just deleting multiple items at a time.