### PR TITLE
Add products to cart

### DIFF
--- a/models/shopcart.py
+++ b/models/shopcart.py
@@ -23,10 +23,20 @@ class Shopcart(object):
     def save(self):
         """ Saves a Shopcart in the database """
         Shopcart.__data.append(self)
+    
+    def add_products(self, products):
+        if type(products) != dict :
+            raise DataValidationError('Invalid products: body of request contained bad or no data')
+        
+        for pid, quantity in products.items():
+            self.add_product(int(pid), quantity)
 
     def add_product(self, pid, quant=1):
         """ Adds a tuple of product, quantity to the product dict """
-        pq_tup = (pid,quant)
+        if pid in self.products:
+            quant += self.products[pid]
+
+        pq_tup = (pid, quant)
         self.products.update( self.__validate_products(pq_tup) )
 
     def delete(self):

--- a/server.py
+++ b/server.py
@@ -121,9 +121,13 @@ def add_product(uid):
     if not cart:
         return jsonify("Cart with id '{}' was not found.".format(uid)), status.HTTP_404_NOT_FOUND
 
-    cart.deserialize(request.get_json())
-    cart.uid = uid
-    cart.save()
+    try:
+        cart.add_products(request.get_json())
+        cart.save()
+    except DataValidationError as e:
+        message = { 'error': e.args[0] }
+        return jsonify(message), status.HTTP_400_BAD_REQUEST
+
     return make_response(jsonify(cart.serialize()), status.HTTP_200_OK)
 
 ######################################################################

--- a/server.py
+++ b/server.py
@@ -111,6 +111,22 @@ def update_shopcart(uid,pid):
 
 
 ######################################################################
+# ADD A PRODUCT TO A SHOPCART
+######################################################################
+@app.route('/shopcarts/<int:uid>/products', methods=['POST'])
+def add_product(uid):
+    """Add a product to the shopcart with the given uid"""
+    cart = Shopcart.find(uid)
+
+    if not cart:
+        return jsonify("Cart with id '{}' was not found.".format(uid)), status.HTTP_404_NOT_FOUND
+
+    cart.deserialize(request.get_json())
+    cart.uid = uid
+    cart.save()
+    return make_response(jsonify(cart.serialize()), status.HTTP_200_OK)
+
+######################################################################
 # DELETE A PRODUCT FROM A SHOPCART
 ######################################################################
 @app.route('/shopcarts/<int:uid>/products/<int:pid>', methods=['DELETE'])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -238,6 +238,38 @@ class TestServer(unittest.TestCase):
         self.assertEqual( resp.status_code, status.HTTP_204_NO_CONTENT )
         cart = server.Shopcart.find(2)
         self.assertEqual( (5 in cart.products), False)
+    
+    def test_add_new_product_to_cart(self):
+        """ Add a new product to the cart """
+        product_count = len(server.Shopcart.find(2).products)
+        data = {'products': {1: 2}}
+        
+        resp = self.app.post('/shopcarts/2/products', data=json.dumps(data), content_type='application/json')
+        data = json.loads(resp.data.decode('utf8'))
+        
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(data['products']), product_count + 1)
+        self.assertEqual(data['products']['1'], 2)
+    
+    def test_add_existing_product_to_cart(self):
+        """ Add an existing product to the cart """
+        product_count = len(server.Shopcart.find(4).products)
+        data = {'products': {5: 2}}
+        
+        resp = self.app.post('/shopcarts/4/products', data=json.dumps(data), content_type='application/json')
+        data = json.loads(resp.data.decode('utf8'))
+        
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(data['products']), product_count)
+        self.assertEqual(data['products']['5'], 9)
+    
+    def test_add_product_to_nonexistent_cart(self):
+        """ Add a product to a nonexistent cart """
+        data = {'products': {1: 2}}
+        
+        resp = self.app.post('/shopcarts/100/products', data=json.dumps(data), content_type='application/json')
+        
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_all_shopcart(self):
         """ List All Shopcarts """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -242,7 +242,7 @@ class TestServer(unittest.TestCase):
     def test_add_new_product_to_cart(self):
         """ Add a new product to the cart """
         product_count = len(server.Shopcart.find(2).products)
-        data = {'products': {1: 2}}
+        data = {1: 2}
         
         resp = self.app.post('/shopcarts/2/products', data=json.dumps(data), content_type='application/json')
         data = json.loads(resp.data.decode('utf8'))
@@ -251,10 +251,23 @@ class TestServer(unittest.TestCase):
         self.assertEqual(len(data['products']), product_count + 1)
         self.assertEqual(data['products']['1'], 2)
     
+    def test_add_multiple_new_products_to_cart(self):
+        """ Add multiple new products to the cart """
+        product_count = len(server.Shopcart.find(2).products)
+        data = {1: 2, 2: 4}
+        
+        resp = self.app.post('/shopcarts/2/products', data=json.dumps(data), content_type='application/json')
+        data = json.loads(resp.data.decode('utf8'))
+        
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(data['products']), product_count + 2)
+        self.assertEqual(data['products']['1'], 2)
+        self.assertEqual(data['products']['2'], 4)
+    
     def test_add_existing_product_to_cart(self):
         """ Add an existing product to the cart """
         product_count = len(server.Shopcart.find(4).products)
-        data = {'products': {5: 2}}
+        data = {5: 2}
         
         resp = self.app.post('/shopcarts/4/products', data=json.dumps(data), content_type='application/json')
         data = json.loads(resp.data.decode('utf8'))
@@ -263,9 +276,30 @@ class TestServer(unittest.TestCase):
         self.assertEqual(len(data['products']), product_count)
         self.assertEqual(data['products']['5'], 9)
     
+    def test_add_multiple_existing_products_to_cart(self):
+        """ Add multiple existing products to the cart """
+        product_count = len(server.Shopcart.find(4).products)
+        data = {5: 2, 13: 2}
+        
+        resp = self.app.post('/shopcarts/4/products', data=json.dumps(data), content_type='application/json')
+        data = json.loads(resp.data.decode('utf8'))
+        
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(data['products']), product_count)
+        self.assertEqual(data['products']['5'], 9)
+        self.assertEqual(data['products']['13'], 23)
+    
+    def test_add_products_in_bad_format_to_cart(self):
+        """ Try to add malformed products to cart """
+        data = [(1, 2), (2, 4)]        
+        resp = self.app.post('/shopcarts/2/products', data=json.dumps(data), content_type='application/json')
+        
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(server.Shopcart.find(2).products), 0)
+    
     def test_add_product_to_nonexistent_cart(self):
         """ Add a product to a nonexistent cart """
-        data = {'products': {1: 2}}
+        data = {1: 2}
         
         resp = self.app.post('/shopcarts/100/products', data=json.dumps(data), content_type='application/json')
         

--- a/tests/test_shopcart.py
+++ b/tests/test_shopcart.py
@@ -119,6 +119,15 @@ class TestShopcart(unittest.TestCase):
         self.assertEqual( len(s.products) ,2 )
         # It's the correct one with correct quant
         self.assertEqual( s.products[34] , 55 )
+    
+    def test_adding_a_product_that_already_exists(self):
+        """ Test to add a product that exists in a cart """
+        shopcart = Shopcart(7, {1: 5})
+        shopcart.save()
+
+        shopcart.add_product(1, 5)
+
+        self.assertEqual(shopcart.products[1], 10)
 
     def test_adding_an_invalid_product(self):
         """ Test to add invalid product"""
@@ -213,6 +222,23 @@ class TestShopcart(unittest.TestCase):
         self.assertEqual(len(Shopcart.find_by_product(6)), 2)
         self.assertEqual(len(Shopcart.find_by_product(7)), 1)
         self.assertEqual(len(Shopcart.find_by_product(1)), 0)   
+    
+    def test_add_multiple_products(self):
+        """ Add multiple products to an existing cart """
+        cart = Shopcart(1, {1: 1})
+        cart.save()
+
+        cart.add_products({1: 2, 2: 4})
+
+        self.assertEqual(len(cart.products), 2)
+        self.assertEqual(cart.products[1], 3)
+        self.assertEqual(cart.products[2], 4)
+
+    def test_add_products_with_invalid_type(self):
+        """ Try to add multiple products not as a dict """
+        cart = Shopcart(1)
+        with self.assertRaises(DataValidationError):
+            cart.add_products([(1, 2), (2, 4)])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This uses a `POST` request to `shopcarts/<uid>/products` to add products to a cart. If the products already existed in the cart, it will add the new quantity to the already existing quantity.

All tests passing and code coverage at 99%.